### PR TITLE
Refactor to pass in environment variables

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_event_publisher (0.1.0)
+    active_record_event_publisher (0.2.0)
       aws-sdk
       rails (~> 5.0)
       sucker_punch (~> 2.0)
@@ -178,4 +178,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.13.6
+   1.14.5

--- a/README.md
+++ b/README.md
@@ -11,21 +11,19 @@ gem 'active_record_event_publisher', :git => 'https://github.com/gamut-code/acti
 ```
 
 ## Setup
-
-This gem uses environment variables for configuration. Be sure the following `ENV` are set in your app:
-
-```
-AWS_REGION=us-east-1
-ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE
-ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED=true (optional)
-```
-
-With the environment variables set, simply add the initializer below to your app:
+Add this configuration initializer to your app
 
 **config/initializers/active_record_event_publisher.rb**
 
 ```ruby
-ActiveRecordEventPublisher.setup
+ActiveRecordEventPublisher.configure do |config|
+  config.aws_region = 'us-east-1' # required field
+  config.aws_secret_access_key = 'secret_key' # required field
+  config.aws_access_key_id = 'key_id' # required field
+  config.queue_url = 'http://example.com'
+  config.enabled = false # only enable in production environment
+  config.log = true # default is false
+end
 ```
 
 Restart your app, and all events will be published to SQS.

--- a/lib/active_record_event_publisher.rb
+++ b/lib/active_record_event_publisher.rb
@@ -8,7 +8,7 @@ require 'wisper/active_record'
 
 module ActiveRecordEventPublisher
   def self.setup
-    if ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE']
+    if ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE'].present?
       Wisper::ActiveRecord.extend_all
       ApplicationRecord.subscribe(Hooks.new)
       Rails.logger.info('ActiveRecordEventPublisher enabled.')

--- a/lib/active_record_event_publisher.rb
+++ b/lib/active_record_event_publisher.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk'
+require 'active_record_event_publisher/configuration'
 require 'active_record_event_publisher/engine'
 require 'active_record_event_publisher/event_builder'
 require 'active_record_event_publisher/hooks'
@@ -7,13 +8,22 @@ require 'wisper'
 require 'wisper/active_record'
 
 module ActiveRecordEventPublisher
-  def self.setup
-    if ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE'].present?
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+
+    if configuration.enabled?
+      queue_url = configuration.queue_url
+      raise ArgumentError, "Set enabled to false rather than passing an empty queue url" if queue_url.blank?
+
       Wisper::ActiveRecord.extend_all
       ApplicationRecord.subscribe(Hooks.new)
       Rails.logger.info('ActiveRecordEventPublisher enabled.')
     else
-      Rails.logger.warn('ActiveRecordEventPublisher not configured, disabling.')
+      Rails.logger.info('ActiveRecordEventPublisher disabled.')
     end
   end
 end

--- a/lib/active_record_event_publisher/configuration.rb
+++ b/lib/active_record_event_publisher/configuration.rb
@@ -1,0 +1,25 @@
+module ActiveRecordEventPublisher
+  class Configuration
+    attr_accessor :aws_region, :aws_secret_access_key, :aws_access_key_id,
+      :log, :enabled, :queue_url
+
+    alias_method :enabled?, :enabled
+    alias_method :log?, :log
+
+    def log
+      @log || false
+    end
+
+    def aws_region
+      @aws_region || raise(ArgumentError, "#{self.class} aws_region required")
+    end
+
+    def aws_access_key_id
+      @aws_access_key_id || raise(ArgumentError, "#{self.class} aws_secret_key required")
+    end
+
+    def aws_secret_access_key
+      @aws_secret_access_key || raise(ArgumentError, "#{self.class} aws_access_key required")
+    end
+  end
+end

--- a/lib/active_record_event_publisher/event_builder.rb
+++ b/lib/active_record_event_publisher/event_builder.rb
@@ -1,18 +1,17 @@
 module ActiveRecordEventPublisher
   class EventBuilder
     def initialize(action, subject)
-      @action   = action
-      @subject  = subject
+      @action = action
+      @subject = subject
     end
 
     def publish
-      return unless ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE'].present?
-      queue = Aws::SQS::Queue.new(ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE'])
+      add_aws_configuration
+      queue = Aws::SQS::Queue.new(configuration.queue_url)
       data = event_data.to_json
       queue.send_message(:message_body => data)
 
-      return unless ENV['ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED'] == 'true'
-      Rails.logger.info("Active Record Event Publisher Event Data: #{data}")
+      configuration.log? && Rails.logger.info("Active Record Event Publisher Event Data: #{data}")
     end
 
     def event_data
@@ -24,6 +23,22 @@ module ActiveRecordEventPublisher
         :changes => @subject.previous_changes,
         :created_at => Time.now.utc
       }
+    end
+
+    private
+
+    def configuration
+      ActiveRecordEventPublisher.configuration
+    end
+
+    def add_aws_configuration
+      Aws.config.update(
+        region: configuration.aws_region,
+        credentials: Aws::Credentials.new(
+          configuration.aws_access_key_id,
+          configuration.aws_secret_access_key
+        )
+      )
     end
   end
 end

--- a/lib/active_record_event_publisher/event_builder.rb
+++ b/lib/active_record_event_publisher/event_builder.rb
@@ -6,11 +6,12 @@ module ActiveRecordEventPublisher
     end
 
     def publish
+      return unless ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE'].present?
       queue = Aws::SQS::Queue.new(ENV['ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE'])
       data = event_data.to_json
       queue.send_message(:message_body => data)
 
-      return unless ENV['ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED']
+      return unless ENV['ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED'] == 'true'
       Rails.logger.info("Active Record Event Publisher Event Data: #{data}")
     end
 

--- a/lib/active_record_event_publisher/version.rb
+++ b/lib/active_record_event_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordEventPublisher
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/lib/active_record_event_publisher/configuration_spec.rb
+++ b/spec/lib/active_record_event_publisher/configuration_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe ActiveRecordEventPublisher::Configuration do
+  subject(:configuration) { described_class.new }
+
+  it { should respond_to(:log) }
+  it { should respond_to(:log?) }
+  it { should respond_to(:enabled) }
+  it { should respond_to(:enabled?) }
+  it { should respond_to(:queue_url) }
+  it { should respond_to(:aws_region) }
+  it { should respond_to(:aws_access_key_id) }
+  it { should respond_to(:aws_secret_access_key) }
+
+  describe '#aws_region' do
+    it 'raises an error if not set' do
+      expect { configuration.aws_region }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#aws_access_key_id' do
+    it 'raises an error if not set' do
+      expect { configuration.aws_access_key_id }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#aws_secret_access_key' do
+    it 'raises an error if not set' do
+      expect { configuration.aws_secret_access_key }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/lib/active_record_event_publisher/event_builder_spec.rb
+++ b/spec/lib/active_record_event_publisher/event_builder_spec.rb
@@ -1,10 +1,28 @@
 require 'rails_helper'
 
 describe ActiveRecordEventPublisher::EventBuilder do
+  let(:queue_url) { 'http://example.com' }
+  let(:log) { true }
+  let(:aws_region) { 'us-east-1'}
+
+  def event_builder(action, user)
+    described_class.new(
+      action,
+      user
+    )
+  end
+
   before do
-    stub_const('ENV',
-               'ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE' => 'NOT_REAL',
-               'AWS_REGION' => 'NOT_REAL')
+    allow_any_instance_of(Aws::SQS::Queue).to receive(:send_message)
+
+    ActiveRecordEventPublisher.configure do |config|
+      config.aws_region = 'us-east-1'
+      config.aws_secret_access_key = 'secret_key'
+      config.aws_access_key_id = 'key_id'
+      config.queue_url = 'http://example.com'
+      config.enabled = true
+      config.log = true
+    end
   end
 
   describe '#publish' do
@@ -12,7 +30,7 @@ describe ActiveRecordEventPublisher::EventBuilder do
       Timecop.freeze
       user = User.create(:name => 'foo')
 
-      event = described_class.new('create', user)
+      event = event_builder('create', user)
       expect_any_instance_of(Aws::SQS::Queue).to receive(:send_message)
         .with(:message_body => event.event_data.to_json)
       event.publish
@@ -20,15 +38,10 @@ describe ActiveRecordEventPublisher::EventBuilder do
     end
 
     it 'writes a log line when the env variable is enabled' do
-      stub_const('ENV',
-                 'ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED' => 'true',
-                 'ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE' => 'NOT_REAL',
-                 'AWS_REGION' => 'NOT_REAL')
-
       Timecop.freeze
       user = User.create(:name => 'foo')
 
-      event     = described_class.new('create', user)
+      event     = event_builder('create', user)
       json_data = event.event_data.to_json
 
       expect_any_instance_of(Aws::SQS::Queue).to receive(:send_message)
@@ -46,7 +59,7 @@ describe ActiveRecordEventPublisher::EventBuilder do
     it 'returns the correct reponse for a create event' do
       user = User.create(:name => 'foo')
 
-      event = described_class.new('create', user)
+      event = event_builder('create', user)
       data = event.event_data
 
       expect(data[:action]).to eq('create')
@@ -57,12 +70,12 @@ describe ActiveRecordEventPublisher::EventBuilder do
       expect(data[:changes]['name']).to eq([nil, 'foo'])
     end
 
-    it 'returns the correct reponse for a update event' do
+    it 'returns the correct reponse for a update event', t:true do
       user = User.create(:name => 'foo')
       user.reload
       user.update_attributes(:name => 'bar')
 
-      event = described_class.new('update', user)
+      event = event_builder('update', user)
       data = event.event_data
 
       expect(data[:action]).to eq('update')
@@ -78,7 +91,7 @@ describe ActiveRecordEventPublisher::EventBuilder do
       user.reload
       user.destroy
 
-      event = described_class.new('destroy', user)
+      event = event_builder('destroy', user)
       data = event.event_data
 
       expect(data[:action]).to eq('destroy')

--- a/spec/lib/active_record_event_publisher/event_builder_spec.rb
+++ b/spec/lib/active_record_event_publisher/event_builder_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 
 describe ActiveRecordEventPublisher::EventBuilder do
   before do
-    stub_const('ENV', 'ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE' => 'NOT_REAL')
+    stub_const('ENV',
+               'ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE' => 'NOT_REAL',
+               'AWS_REGION' => 'NOT_REAL')
   end
 
   describe '#publish' do
@@ -19,8 +21,9 @@ describe ActiveRecordEventPublisher::EventBuilder do
 
     it 'writes a log line when the env variable is enabled' do
       stub_const('ENV',
-                 'ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED' => true,
-                 'ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE' => 'NOT_REAL')
+                 'ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED' => 'true',
+                 'ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE' => 'NOT_REAL',
+                 'AWS_REGION' => 'NOT_REAL')
 
       Timecop.freeze
       user = User.create(:name => 'foo')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,8 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'timecop'
+require 'sucker_punch/testing/inline'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
## Backstory (written by @ywong)
Currently, these will not be triggered only if those keys don't exist in people's `.env` file. Ideally, these should also not be triggered if our `.env` has values set as:

```
ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE=
ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED=false
```

Slack convo: https://gamut-team.slack.com/archives/C3W8YN7EF/p1494420420765518

## Refactor (written by @paddingtonsbear) 
After spending a couple hours debugging the issue above with @JoshCheek and @ywong19, we decided to refactor the gem to pass in the variables needed rather than the gem depending on them being supplied in your environment variables. The proposed change makes it easier to configure the gem with the `needed` variables without having to dig through source code

```ruby
# old implementation 
# variables you think you need
# - AWS_REGION, 
# - ACTIVE_RECORD_EVENT_PUBLISHER_QUEUE
# - ACTIVE_RECORD_EVENT_PUBLISHER_LOGGER_ENABLED
# 
# extra variables you need but dont know about
# - AWS_ACCESS_KEY_ID
# - AWS_SECRET_ACCESS_KEY
#
ActiveRecordEventPublisher.setup
```

```ruby
# proposed implementation
ActiveRecordEventPublisher.configure do |config|
  config.aws_region = 'us-east-1' # required field
  config.aws_secret_access_key = 'secret_key' # required field
  config.aws_access_key_id = 'key_id' # required field
  config.queue_url = 'http://example.com'
  config.enabled = false # only enable in production environment
  config.log = true # default is false
end
```

@darbyfrey @gamut-code/platform 
cc @JoshCheek @paddingtonsbear 