### PR TITLE
Remove the Aws credential initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@ Add this configuration initializer to your app
 
 ```ruby
 ActiveRecordEventPublisher.configure do |config|
-  config.aws_region = 'us-east-1' # required field
-  config.aws_secret_access_key = 'secret_key' # required field
-  config.aws_access_key_id = 'key_id' # required field
   config.queue_url = 'http://example.com'
   config.enabled = false # only enable in production environment
   config.log = true # default is false

--- a/lib/active_record_event_publisher/configuration.rb
+++ b/lib/active_record_event_publisher/configuration.rb
@@ -1,25 +1,12 @@
 module ActiveRecordEventPublisher
   class Configuration
-    attr_accessor :aws_region, :aws_secret_access_key, :aws_access_key_id,
-      :log, :enabled, :queue_url
+    attr_accessor :log, :enabled, :queue_url
 
     alias_method :enabled?, :enabled
     alias_method :log?, :log
 
     def log
       @log || false
-    end
-
-    def aws_region
-      @aws_region || raise(ArgumentError, "#{self.class} aws_region required")
-    end
-
-    def aws_access_key_id
-      @aws_access_key_id || raise(ArgumentError, "#{self.class} aws_secret_key required")
-    end
-
-    def aws_secret_access_key
-      @aws_secret_access_key || raise(ArgumentError, "#{self.class} aws_access_key required")
     end
   end
 end

--- a/lib/active_record_event_publisher/event_builder.rb
+++ b/lib/active_record_event_publisher/event_builder.rb
@@ -6,7 +6,6 @@ module ActiveRecordEventPublisher
     end
 
     def publish
-      add_aws_configuration
       queue = Aws::SQS::Queue.new(configuration.queue_url)
       data = event_data.to_json
       queue.send_message(:message_body => data)
@@ -29,16 +28,6 @@ module ActiveRecordEventPublisher
 
     def configuration
       ActiveRecordEventPublisher.configuration
-    end
-
-    def add_aws_configuration
-      Aws.config.update(
-        region: configuration.aws_region,
-        credentials: Aws::Credentials.new(
-          configuration.aws_access_key_id,
-          configuration.aws_secret_access_key
-        )
-      )
     end
   end
 end

--- a/lib/active_record_event_publisher/version.rb
+++ b/lib/active_record_event_publisher/version.rb
@@ -1,3 +1,3 @@
 module ActiveRecordEventPublisher
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/spec/lib/active_record_event_publisher/configuration_spec.rb
+++ b/spec/lib/active_record_event_publisher/configuration_spec.rb
@@ -8,25 +8,4 @@ describe ActiveRecordEventPublisher::Configuration do
   it { should respond_to(:enabled) }
   it { should respond_to(:enabled?) }
   it { should respond_to(:queue_url) }
-  it { should respond_to(:aws_region) }
-  it { should respond_to(:aws_access_key_id) }
-  it { should respond_to(:aws_secret_access_key) }
-
-  describe '#aws_region' do
-    it 'raises an error if not set' do
-      expect { configuration.aws_region }.to raise_error(ArgumentError)
-    end
-  end
-
-  describe '#aws_access_key_id' do
-    it 'raises an error if not set' do
-      expect { configuration.aws_access_key_id }.to raise_error(ArgumentError)
-    end
-  end
-
-  describe '#aws_secret_access_key' do
-    it 'raises an error if not set' do
-      expect { configuration.aws_secret_access_key }.to raise_error(ArgumentError)
-    end
-  end
 end

--- a/spec/lib/active_record_event_publisher/event_builder_spec.rb
+++ b/spec/lib/active_record_event_publisher/event_builder_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe ActiveRecordEventPublisher::EventBuilder do
   let(:queue_url) { 'http://example.com' }
   let(:log) { true }
-  let(:aws_region) { 'us-east-1'}
 
   def event_builder(action, user)
     described_class.new(
@@ -16,9 +15,6 @@ describe ActiveRecordEventPublisher::EventBuilder do
     allow_any_instance_of(Aws::SQS::Queue).to receive(:send_message)
 
     ActiveRecordEventPublisher.configure do |config|
-      config.aws_region = 'us-east-1'
-      config.aws_secret_access_key = 'secret_key'
-      config.aws_access_key_id = 'key_id'
       config.queue_url = 'http://example.com'
       config.enabled = true
       config.log = true

--- a/spec/lib/active_record_event_publisher_spec.rb
+++ b/spec/lib/active_record_event_publisher_spec.rb
@@ -3,9 +3,6 @@ require 'rails_helper'
 describe ActiveRecordEventPublisher do
   def configure(enabled, queue_url='http://example.com')
     described_class.configure do |config|
-      config.aws_region = 'us-east-1'
-      config.aws_secret_access_key = 'secret_key'
-      config.aws_access_key_id = 'key_id'
       config.queue_url = queue_url
       config.enabled = enabled
       config.log = true


### PR DESCRIPTION
cc @ywong19 @ethangunderson 

So `aws-sdk` does some magic to determine the credential keys and there is no need for us to pass them in.